### PR TITLE
dep: add cors as a dependency in package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "apollo-server-express": "^1.3.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.2",
+    "cors": "^2.8.4",
     "express": "^4.16.2",
     "graphql": "^0.11.7",
     "graphql-tools": "^2.13.0",


### PR DESCRIPTION
`cors` is used in server, but not listed in package.json